### PR TITLE
(Samples): add responsive layout samples — Team Standup Summary & Project Dashboard

### DIFF
--- a/samples/catalog.json
+++ b/samples/catalog.json
@@ -84,6 +84,16 @@
       "name": "Simple Time Off Request",
       "description": "The Simple Time Off Request Card is designed for ease and efficiency, allowing users to quickly submit their time off requests. Its minimalistic design ensures a clean and user-friendly experience while offering opportunities for visual customization.",
       "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Card-Samples/main/samples/simple-time-off-request/card.json"
+    },
+    {
+      "name": "Team Standup Summary",
+      "description": "The Team Standup Summary Card provides a quick overview of your team's daily standup status. It uses Layout.AreaGrid to display team members in a responsive 2-column grid on desktop that collapses to a single-column stack on mobile, with highlighted blockers for immediate visibility.",
+      "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Card-Samples/main/samples/team-standup-summary/card.json"
+    },
+    {
+      "name": "Project Dashboard",
+      "description": "The Project Dashboard Card provides a comprehensive at-a-glance view of project health with responsive KPI tiles, milestone timeline, team roster, and activity feed. Uses multiple Layout.AreaGrid definitions with targetWidth breakpoints to adapt from a 4-column KPI row on desktop to a 2x2 grid on tablet to a stacked layout on mobile.",
+      "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Card-Samples/main/samples/project-dashboard/card.json"
     }
   ]
 }

--- a/samples/project-dashboard/README.md
+++ b/samples/project-dashboard/README.md
@@ -1,0 +1,121 @@
+# Project Dashboard
+
+## Summary
+
+The **Project Dashboard Card** provides a comprehensive at-a-glance view of a project's health. It features **KPI tiles** that rearrange responsively from a 4-column row on wide screens to a 2x2 grid on narrow screens to a single-column stack on very narrow screens. The milestones timeline and team roster sit side-by-side on desktop but stack vertically on mobile, ensuring readability across all device widths.
+
+_bot-sent_ card example:
+
+![picture of the extension in action](assets/project-dashboard-card.png)
+
+## Compatibility
+
+![Adaptive Card Version](https://img.shields.io/badge/Adaptive%20Card%20Version-1.5-green.svg)
+
+## Solution
+
+Solution|Author(s)
+--------|---------
+Project Dashboard | <a href="https://github.com/VikrantSingh01"><img align="center" width="28" height="28" src="https://wsrv.nl/?url=https://avatars.githubusercontent.com/u/VikrantSingh01?v=4&w=36&h=36&fit=cover&mask=circle"></a> &nbsp; [Vikrant Singh](https://github.com/VikrantSingh01)
+
+## Version history
+
+Version|Date|Comments
+-------|----|--------
+1.0| February 14, 2026 | Initial release
+
+### Disclaimer
+
+_**THIS CODE IS PROVIDED _AS IS_ WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.**_
+
+## Responsive Layouts
+
+This card utilizes the responsive framework, allowing for multiple layouts and content modifications for specific width ranges. For more details on coding with this framework, see <a href="https://learn.microsoft.com/en-us/microsoftteams/platform/task-modules-and-cards/cards/cards-format?tabs=adaptive-md%2Cdesktop%2Cconnector-html#adaptive-card-responsive-layout">Design responsive Adaptive Cards</a>.
+
+### Layout Breakpoints
+
+| Width | KPI Tiles | Milestones + Team | Activity Timestamps |
+|---|---|---|---|
+| **VeryNarrow** | Single column stack | Single column stack | Hidden |
+| **Narrow** | 2x2 grid | Single column stack | Visible |
+| **Standard+** | 4 columns in a row | Side-by-side (60/40 split) | Visible |
+
+### Responsive Features Used
+
+- **Two `Layout.AreaGrid` layouts on KPI container** — 4-column grid at Standard+, 2x2 grid at Narrow, default stack at VeryNarrow
+- **`Layout.AreaGrid` on milestones/team section** — side-by-side at Standard+, stacked on mobile
+- **`targetWidth: "AtLeast:Narrow"`** — shows milestone dates and activity timestamps only when there's room
+- **`targetWidth: "VeryNarrow"`** — condensed due date display for very narrow screens
+- **`Badge`** component — project status indicator
+- **`Icon`** elements — milestone status indicators (completed, in-progress, pending)
+- **`RichTextBlock`** — mixed-weight activity feed entries
+
+<br/><br/>
+
+## 1) Personalize This Card
+
+### Step-by-step instructions and tips
+
+#### 1) Copy the card JSON into the Designer Tool
+
+Copy the [card](card.json) payload and click on the **'Open in Designer'** button to start working in the Designer platform.
+
+_To create a "full width" card, add the following code to the JSON._
+
+```json
+"msTeams": {
+  "width": "full"
+}
+```
+
+<a href="https://dev.teams.microsoft.com/cards/new" target="_blank">
+  <img src="../../assets/open_designer_button.png" width="190" alt="Open in Adaptive Card Designer" />
+</a>
+
+#### 2) Update KPI Tiles
+
+Replace the completion percentage, task counts, bug count, and days remaining with your actual project metrics.
+
+#### 3) Update Milestones
+
+Customize the milestone names, dates, and status icons to match your project plan.
+
+#### 4) Update Team Members
+
+Replace avatars, names, and roles with your project team.
+
+#### 5) Connect to Your Data Source
+
+Integrate with Azure DevOps, Jira, GitHub Projects, or your preferred project management tool to auto-populate metrics.
+
+#### 6) Update Button Actions
+
+Point the "Open project" and "View all tasks" buttons to your project's actual URLs.
+
+## 2) Test Your Card
+
+Road test your cards considering the following:
+
+* **Themes:** Light Mode, Dark Mode, High Contrast
+* **Common widths:** Chat, Channel, Meeting Chat, Phone (iOS - Portrait/landscape, Android - Portrait/landscape), Tablet (iOS - Portrait/landscape, Android - Portrait/landscape)
+* **Accessibility:** Color contrast, keyboard tabbing, voice assistance
+
+## Implementation Details
+
+* The **KPI tiles section** uses two `Layout.AreaGrid` definitions on a single container — one targeting `atLeast:Standard` (4-column row) and another targeting `Narrow` (2x2 grid). At VeryNarrow, it falls back to the default `Layout.Stack`.
+
+* The **milestones + team section** uses `Layout.AreaGrid` with `targetWidth: "atLeast:Standard"` for a 60/40 split. On narrower widths, milestones and team stack vertically.
+
+* **Milestone dates** and **activity timestamps** use `targetWidth: "AtLeast:Narrow"` so they're hidden on VeryNarrow to save horizontal space.
+
+* The **due date** in the header uses dual rendering: inline with the badge on Narrow+ and a separate line on VeryNarrow.
+
+## Resources & Tools
+
+* **Learn**: [Design Adaptive Cards for Your Teams App](https://learn.microsoft.com/en-us/microsoftteams/platform/task-modules-and-cards/cards/design-effective-cards?tabs=design) and [Build Cards](https://learn.microsoft.com/en-us/microsoftteams/platform/task-modules-and-cards/what-are-cards)
+* **Design**: [The Microsoft Teams UI Kit](https://www.figma.com/community/file/916836509871353159)
+* **Build**: [Adaptive Card Designer](https://dev.teams.microsoft.com/cards)
+
+## Contribute
+
+Refer to the [contribution docs](/CONTRIBUTE.md) for more information.

--- a/samples/project-dashboard/card.json
+++ b/samples/project-dashboard/card.json
@@ -1,0 +1,785 @@
+{
+    "type": "AdaptiveCard",
+    "$schema": "https://adaptivecards.io/schemas/adaptive-card.json",
+    "version": "1.5",
+    "body": [
+        {
+            "type": "TextBlock",
+            "text": "Contoso Mobile App Redesign",
+            "wrap": true,
+            "size": "Large",
+            "weight": "Bolder"
+        },
+        {
+            "type": "ColumnSet",
+            "columns": [
+                {
+                    "type": "Column",
+                    "width": "stretch",
+                    "items": [
+                        {
+                            "type": "Badge",
+                            "text": "In Progress",
+                            "style": "Informative",
+                            "appearance": "Tint",
+                            "icon": "ArrowSync",
+                            "size": "Large"
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "Due Mar 15, 2025",
+                            "wrap": true,
+                            "size": "Small",
+                            "isSubtle": true
+                        }
+                    ],
+                    "verticalContentAlignment": "Center",
+                    "targetWidth": "AtLeast:Narrow"
+                }
+            ]
+        },
+        {
+            "type": "TextBlock",
+            "text": "Due Mar 15, 2025",
+            "wrap": true,
+            "size": "Small",
+            "isSubtle": true,
+            "targetWidth": "VeryNarrow",
+            "spacing": "ExtraSmall"
+        },
+        {
+            "type": "Container",
+            "layouts": [
+                {
+                    "type": "Layout.AreaGrid",
+                    "targetWidth": "atLeast:Standard",
+                    "columns": [25, 25, 25],
+                    "areas": [
+                        { "name": "kpi1" },
+                        { "name": "kpi2", "column": 2 },
+                        { "name": "kpi3", "column": 3 },
+                        { "name": "kpi4", "column": 4 }
+                    ],
+                    "columnSpacing": "Small"
+                },
+                {
+                    "type": "Layout.AreaGrid",
+                    "targetWidth": "Narrow",
+                    "columns": [50],
+                    "areas": [
+                        { "name": "kpi1" },
+                        { "name": "kpi2", "column": 2 },
+                        { "name": "kpi3", "row": 2 },
+                        { "name": "kpi4", "column": 2, "row": 2 }
+                    ],
+                    "columnSpacing": "Small",
+                    "rowSpacing": "Small"
+                }
+            ],
+            "items": [
+                {
+                    "type": "Container",
+                    "grid.area": "kpi1",
+                    "style": "emphasis",
+                    "roundedCorners": true,
+                    "showBorder": true,
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "Completion",
+                            "wrap": true,
+                            "size": "Small",
+                            "isSubtle": true
+                        },
+                        {
+                            "type": "TextBlock",
+                            "text": "68%",
+                            "wrap": true,
+                            "size": "ExtraLarge",
+                            "weight": "Bolder",
+                            "color": "Good",
+                            "spacing": "ExtraSmall"
+                        }
+                    ]
+                },
+                {
+                    "type": "Container",
+                    "grid.area": "kpi2",
+                    "style": "emphasis",
+                    "roundedCorners": true,
+                    "showBorder": true,
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "Tasks Done",
+                            "wrap": true,
+                            "size": "Small",
+                            "isSubtle": true
+                        },
+                        {
+                            "type": "TextBlock",
+                            "text": "34 / 50",
+                            "wrap": true,
+                            "size": "ExtraLarge",
+                            "weight": "Bolder",
+                            "spacing": "ExtraSmall"
+                        }
+                    ]
+                },
+                {
+                    "type": "Container",
+                    "grid.area": "kpi3",
+                    "style": "emphasis",
+                    "roundedCorners": true,
+                    "showBorder": true,
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "Open Bugs",
+                            "wrap": true,
+                            "size": "Small",
+                            "isSubtle": true
+                        },
+                        {
+                            "type": "TextBlock",
+                            "text": "7",
+                            "wrap": true,
+                            "size": "ExtraLarge",
+                            "weight": "Bolder",
+                            "color": "Attention",
+                            "spacing": "ExtraSmall"
+                        }
+                    ]
+                },
+                {
+                    "type": "Container",
+                    "grid.area": "kpi4",
+                    "style": "emphasis",
+                    "roundedCorners": true,
+                    "showBorder": true,
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "Days Left",
+                            "wrap": true,
+                            "size": "Small",
+                            "isSubtle": true
+                        },
+                        {
+                            "type": "TextBlock",
+                            "text": "31",
+                            "wrap": true,
+                            "size": "ExtraLarge",
+                            "weight": "Bolder",
+                            "color": "Warning",
+                            "spacing": "ExtraSmall"
+                        }
+                    ]
+                }
+            ],
+            "spacing": "Medium",
+            "separator": true
+        },
+        {
+            "type": "Container",
+            "layouts": [
+                {
+                    "type": "Layout.AreaGrid",
+                    "targetWidth": "atLeast:Standard",
+                    "columns": [60],
+                    "areas": [
+                        { "name": "milestones" },
+                        { "name": "team", "column": 2 }
+                    ],
+                    "columnSpacing": "Default"
+                }
+            ],
+            "items": [
+                {
+                    "type": "Container",
+                    "grid.area": "milestones",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "Milestones",
+                            "wrap": true,
+                            "weight": "Bolder",
+                            "size": "Small"
+                        },
+                        {
+                            "type": "ColumnSet",
+                            "columns": [
+                                {
+                                    "type": "Column",
+                                    "width": "auto",
+                                    "items": [
+                                        {
+                                            "type": "Icon",
+                                            "name": "CheckmarkCircle",
+                                            "size": "xSmall",
+                                            "style": "Filled",
+                                            "color": "Good"
+                                        }
+                                    ],
+                                    "verticalContentAlignment": "Center"
+                                },
+                                {
+                                    "type": "Column",
+                                    "width": "stretch",
+                                    "items": [
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "Design review",
+                                            "wrap": true,
+                                            "size": "Small"
+                                        }
+                                    ],
+                                    "spacing": "Small"
+                                },
+                                {
+                                    "type": "Column",
+                                    "width": "auto",
+                                    "items": [
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "Jan 20",
+                                            "wrap": true,
+                                            "size": "Small",
+                                            "isSubtle": true
+                                        }
+                                    ],
+                                    "targetWidth": "AtLeast:Narrow"
+                                }
+                            ],
+                            "spacing": "Small"
+                        },
+                        {
+                            "type": "ColumnSet",
+                            "columns": [
+                                {
+                                    "type": "Column",
+                                    "width": "auto",
+                                    "items": [
+                                        {
+                                            "type": "Icon",
+                                            "name": "CheckmarkCircle",
+                                            "size": "xSmall",
+                                            "style": "Filled",
+                                            "color": "Good"
+                                        }
+                                    ],
+                                    "verticalContentAlignment": "Center"
+                                },
+                                {
+                                    "type": "Column",
+                                    "width": "stretch",
+                                    "items": [
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "API integration",
+                                            "wrap": true,
+                                            "size": "Small"
+                                        }
+                                    ],
+                                    "spacing": "Small"
+                                },
+                                {
+                                    "type": "Column",
+                                    "width": "auto",
+                                    "items": [
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "Feb 3",
+                                            "wrap": true,
+                                            "size": "Small",
+                                            "isSubtle": true
+                                        }
+                                    ],
+                                    "targetWidth": "AtLeast:Narrow"
+                                }
+                            ],
+                            "spacing": "ExtraSmall"
+                        },
+                        {
+                            "type": "ColumnSet",
+                            "columns": [
+                                {
+                                    "type": "Column",
+                                    "width": "auto",
+                                    "items": [
+                                        {
+                                            "type": "Icon",
+                                            "name": "ArrowSync",
+                                            "size": "xSmall",
+                                            "color": "Accent"
+                                        }
+                                    ],
+                                    "verticalContentAlignment": "Center"
+                                },
+                                {
+                                    "type": "Column",
+                                    "width": "stretch",
+                                    "items": [
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "Beta testing",
+                                            "wrap": true,
+                                            "size": "Small",
+                                            "weight": "Bolder"
+                                        }
+                                    ],
+                                    "spacing": "Small"
+                                },
+                                {
+                                    "type": "Column",
+                                    "width": "auto",
+                                    "items": [
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "Feb 28",
+                                            "wrap": true,
+                                            "size": "Small",
+                                            "isSubtle": true
+                                        }
+                                    ],
+                                    "targetWidth": "AtLeast:Narrow"
+                                }
+                            ],
+                            "spacing": "ExtraSmall"
+                        },
+                        {
+                            "type": "ColumnSet",
+                            "columns": [
+                                {
+                                    "type": "Column",
+                                    "width": "auto",
+                                    "items": [
+                                        {
+                                            "type": "Icon",
+                                            "name": "Circle",
+                                            "size": "xSmall",
+                                            "color": "Default"
+                                        }
+                                    ],
+                                    "verticalContentAlignment": "Center"
+                                },
+                                {
+                                    "type": "Column",
+                                    "width": "stretch",
+                                    "items": [
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "GA release",
+                                            "wrap": true,
+                                            "size": "Small",
+                                            "isSubtle": true
+                                        }
+                                    ],
+                                    "spacing": "Small"
+                                },
+                                {
+                                    "type": "Column",
+                                    "width": "auto",
+                                    "items": [
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "Mar 15",
+                                            "wrap": true,
+                                            "size": "Small",
+                                            "isSubtle": true
+                                        }
+                                    ],
+                                    "targetWidth": "AtLeast:Narrow"
+                                }
+                            ],
+                            "spacing": "ExtraSmall"
+                        }
+                    ]
+                },
+                {
+                    "type": "Container",
+                    "grid.area": "team",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "Team",
+                            "wrap": true,
+                            "weight": "Bolder",
+                            "size": "Small"
+                        },
+                        {
+                            "type": "ColumnSet",
+                            "columns": [
+                                {
+                                    "type": "Column",
+                                    "width": "auto",
+                                    "items": [
+                                        {
+                                            "type": "Image",
+                                            "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/insights/assets/avatar-requestor.png",
+                                            "width": "24px",
+                                            "height": "24px",
+                                            "style": "Person"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "Column",
+                                    "width": "stretch",
+                                    "items": [
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "Alex Chen",
+                                            "wrap": true,
+                                            "size": "Small",
+                                            "weight": "Bolder"
+                                        },
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "Project Lead",
+                                            "wrap": true,
+                                            "size": "Small",
+                                            "isSubtle": true,
+                                            "spacing": "None"
+                                        }
+                                    ],
+                                    "spacing": "Small"
+                                }
+                            ],
+                            "spacing": "Small"
+                        },
+                        {
+                            "type": "ColumnSet",
+                            "columns": [
+                                {
+                                    "type": "Column",
+                                    "width": "auto",
+                                    "items": [
+                                        {
+                                            "type": "Image",
+                                            "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/insights/assets/avatar-approver1.png",
+                                            "width": "24px",
+                                            "height": "24px",
+                                            "style": "Person"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "Column",
+                                    "width": "stretch",
+                                    "items": [
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "Priya Sharma",
+                                            "wrap": true,
+                                            "size": "Small",
+                                            "weight": "Bolder"
+                                        },
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "UX Designer",
+                                            "wrap": true,
+                                            "size": "Small",
+                                            "isSubtle": true,
+                                            "spacing": "None"
+                                        }
+                                    ],
+                                    "spacing": "Small"
+                                }
+                            ],
+                            "spacing": "Small"
+                        },
+                        {
+                            "type": "ColumnSet",
+                            "columns": [
+                                {
+                                    "type": "Column",
+                                    "width": "auto",
+                                    "items": [
+                                        {
+                                            "type": "Image",
+                                            "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/insights/assets/avatar-approver2.png",
+                                            "width": "24px",
+                                            "height": "24px",
+                                            "style": "Person"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "Column",
+                                    "width": "stretch",
+                                    "items": [
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "Marcus Johnson",
+                                            "wrap": true,
+                                            "size": "Small",
+                                            "weight": "Bolder"
+                                        },
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "iOS Developer",
+                                            "wrap": true,
+                                            "size": "Small",
+                                            "isSubtle": true,
+                                            "spacing": "None"
+                                        }
+                                    ],
+                                    "spacing": "Small"
+                                }
+                            ],
+                            "spacing": "Small"
+                        },
+                        {
+                            "type": "ColumnSet",
+                            "columns": [
+                                {
+                                    "type": "Column",
+                                    "width": "auto",
+                                    "items": [
+                                        {
+                                            "type": "Image",
+                                            "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/insights/assets/avatar-approver3.png",
+                                            "width": "24px",
+                                            "height": "24px",
+                                            "style": "Person"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "Column",
+                                    "width": "stretch",
+                                    "items": [
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "Sara Kim",
+                                            "wrap": true,
+                                            "size": "Small",
+                                            "weight": "Bolder"
+                                        },
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "Android Developer",
+                                            "wrap": true,
+                                            "size": "Small",
+                                            "isSubtle": true,
+                                            "spacing": "None"
+                                        }
+                                    ],
+                                    "spacing": "Small"
+                                }
+                            ],
+                            "spacing": "Small"
+                        }
+                    ]
+                }
+            ],
+            "spacing": "Medium",
+            "separator": true
+        },
+        {
+            "type": "Container",
+            "spacing": "Medium",
+            "separator": true,
+            "items": [
+                {
+                    "type": "TextBlock",
+                    "text": "Recent Activity",
+                    "wrap": true,
+                    "weight": "Bolder",
+                    "size": "Small"
+                },
+                {
+                    "type": "ColumnSet",
+                    "columns": [
+                        {
+                            "type": "Column",
+                            "width": "auto",
+                            "items": [
+                                {
+                                    "type": "Icon",
+                                    "name": "Checkmark",
+                                    "size": "xxSmall",
+                                    "color": "Good"
+                                }
+                            ],
+                            "verticalContentAlignment": "Center"
+                        },
+                        {
+                            "type": "Column",
+                            "width": "stretch",
+                            "items": [
+                                {
+                                    "type": "RichTextBlock",
+                                    "inlines": [
+                                        {
+                                            "type": "TextRun",
+                                            "text": "Alex ",
+                                            "weight": "Bolder",
+                                            "size": "Small"
+                                        },
+                                        {
+                                            "type": "TextRun",
+                                            "text": "merged PR #142 — Auth flow redesign",
+                                            "size": "Small"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "spacing": "Small"
+                        },
+                        {
+                            "type": "Column",
+                            "width": "auto",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "2h ago",
+                                    "wrap": true,
+                                    "size": "Small",
+                                    "isSubtle": true
+                                }
+                            ],
+                            "targetWidth": "AtLeast:Narrow"
+                        }
+                    ],
+                    "spacing": "Small"
+                },
+                {
+                    "type": "ColumnSet",
+                    "columns": [
+                        {
+                            "type": "Column",
+                            "width": "auto",
+                            "items": [
+                                {
+                                    "type": "Icon",
+                                    "name": "Bug",
+                                    "size": "xxSmall",
+                                    "color": "Attention"
+                                }
+                            ],
+                            "verticalContentAlignment": "Center"
+                        },
+                        {
+                            "type": "Column",
+                            "width": "stretch",
+                            "items": [
+                                {
+                                    "type": "RichTextBlock",
+                                    "inlines": [
+                                        {
+                                            "type": "TextRun",
+                                            "text": "Marcus ",
+                                            "weight": "Bolder",
+                                            "size": "Small"
+                                        },
+                                        {
+                                            "type": "TextRun",
+                                            "text": "opened bug #87 — Nav bar overlap on iPad",
+                                            "size": "Small"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "spacing": "Small"
+                        },
+                        {
+                            "type": "Column",
+                            "width": "auto",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "5h ago",
+                                    "wrap": true,
+                                    "size": "Small",
+                                    "isSubtle": true
+                                }
+                            ],
+                            "targetWidth": "AtLeast:Narrow"
+                        }
+                    ],
+                    "spacing": "ExtraSmall"
+                },
+                {
+                    "type": "ColumnSet",
+                    "columns": [
+                        {
+                            "type": "Column",
+                            "width": "auto",
+                            "items": [
+                                {
+                                    "type": "Icon",
+                                    "name": "Design",
+                                    "size": "xxSmall",
+                                    "color": "Accent"
+                                }
+                            ],
+                            "verticalContentAlignment": "Center"
+                        },
+                        {
+                            "type": "Column",
+                            "width": "stretch",
+                            "items": [
+                                {
+                                    "type": "RichTextBlock",
+                                    "inlines": [
+                                        {
+                                            "type": "TextRun",
+                                            "text": "Priya ",
+                                            "weight": "Bolder",
+                                            "size": "Small"
+                                        },
+                                        {
+                                            "type": "TextRun",
+                                            "text": "uploaded new mockups for Settings page",
+                                            "size": "Small"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "spacing": "Small"
+                        },
+                        {
+                            "type": "Column",
+                            "width": "auto",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "1d ago",
+                                    "wrap": true,
+                                    "size": "Small",
+                                    "isSubtle": true
+                                }
+                            ],
+                            "targetWidth": "AtLeast:Narrow"
+                        }
+                    ],
+                    "spacing": "ExtraSmall"
+                }
+            ]
+        },
+        {
+            "type": "ActionSet",
+            "spacing": "Medium",
+            "actions": [
+                {
+                    "type": "Action.OpenUrl",
+                    "title": "Open project",
+                    "url": "https://github.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples"
+                },
+                {
+                    "type": "Action.OpenUrl",
+                    "title": "View all tasks",
+                    "url": "https://github.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples"
+                }
+            ]
+        }
+    ]
+}

--- a/samples/team-standup-summary/README.md
+++ b/samples/team-standup-summary/README.md
@@ -1,0 +1,107 @@
+# Team Standup Summary
+
+## Summary
+
+The **Team Standup Summary Card** provides a quick overview of your team's daily standup status. It displays each team member's progress, blockers, and current tasks in a **responsive grid layout** that adapts from a 2-column grid on desktop to a single-column stack on mobile. A highlighted blocker summary ensures critical issues get immediate visibility.
+
+_bot-sent_ card example:
+
+![picture of the extension in action](assets/team-standup-summary-card.png)
+
+## Compatibility
+
+![Adaptive Card Version](https://img.shields.io/badge/Adaptive%20Card%20Version-1.5-green.svg)
+
+## Solution
+
+Solution|Author(s)
+--------|---------
+Team Standup Summary | <a href="https://github.com/VikrantSingh01"><img align="center" width="28" height="28" src="https://wsrv.nl/?url=https://avatars.githubusercontent.com/u/VikrantSingh01?v=4&w=36&h=36&fit=cover&mask=circle"></a> &nbsp; [Vikrant Singh](https://github.com/VikrantSingh01)
+
+## Version history
+
+Version|Date|Comments
+-------|----|--------
+1.0| February 14, 2026 | Initial release
+
+### Disclaimer
+
+_**THIS CODE IS PROVIDED _AS IS_ WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.**_
+
+## Responsive Layouts
+
+This card utilizes the responsive framework, allowing for multiple layouts and content modifications for specific width ranges. For more details on coding with this framework, see <a href="https://learn.microsoft.com/en-us/microsoftteams/platform/task-modules-and-cards/cards/cards-format?tabs=adaptive-md%2Cdesktop%2Cconnector-html#adaptive-card-responsive-layout">Design responsive Adaptive Cards</a>.
+
+### Layout Breakpoints
+
+| Width | Layout | Description |
+|---|---|---|
+| **VeryNarrow** | Single column stack | Team members stack vertically; sprint info collapses to separate lines |
+| **Narrow** | Single column stack | Team members stack vertically; sprint info shows side-by-side |
+| **Standard+** | 2x2 grid | Team member cards displayed in a 2-column grid via `Layout.AreaGrid` |
+
+### Responsive Features Used
+
+- **`Layout.AreaGrid`** with `targetWidth: "atLeast:Standard"` — switches between 2-column grid and default stack layout
+- **`targetWidth: "VeryNarrow"`** on elements — shows condensed header layout for very narrow screens
+- **`targetWidth: "AtLeast:Narrow"`** on elements — shows inline sprint info on wider screens
+- **`Badge`** component — visual status indicators (On track, Blocked, Not reported)
+
+<br/><br/>
+
+## 1) Personalize This Card
+
+### Step-by-step instructions and tips
+
+#### 1) Copy the card JSON into the Designer Tool
+
+Copy the [card](card.json) payload and click on the **'Open in Designer'** button to start working in the Designer platform.
+
+_To create a "full width" card, add the following code to the JSON._
+
+```json
+"msTeams": {
+  "width": "full"
+}
+```
+
+<a href="https://dev.teams.microsoft.com/cards/new" target="_blank">
+  <img src="../../assets/open_designer_button.png" width="190" alt="Open in Adaptive Card Designer" />
+</a>
+
+#### 2) Update Team Members
+
+Replace the team member names, avatars, and status updates with your actual team data.
+
+#### 3) Connect to Your Data Source
+
+Integrate with your standup bot or project management tool to automatically populate daily updates.
+
+#### 4) Update Button Actions
+
+Customize the "View sprint board" and "Submit update" buttons to link to your team's actual tools.
+
+## 2) Test Your Card
+
+Road test your cards considering the following:
+
+* **Themes:** Light Mode, Dark Mode, High Contrast
+* **Common widths:** Chat, Channel, Meeting Chat, Phone (iOS - Portrait/landscape, Android - Portrait/landscape), Tablet (iOS - Portrait/landscape, Android - Portrait/landscape)
+* **Accessibility:** Color contrast, keyboard tabbing, voice assistance
+
+## Implementation Details
+
+* We use `Layout.AreaGrid` on the team member container to show a **2x2 grid** on Standard+ widths and fall back to `Layout.Stack` on Narrow/VeryNarrow widths.
+* The header row uses **dual rendering**: a `ColumnSet` for Narrow+ and a stacked `Container` for VeryNarrow, ensuring the team name and badge don't get squished.
+* The sprint footer similarly adapts: side-by-side on Narrow+ and stacked on VeryNarrow.
+* The blocker summary container uses the `attention` style to visually highlight urgent issues.
+
+## Resources & Tools
+
+* **Learn**: [Design Adaptive Cards for Your Teams App](https://learn.microsoft.com/en-us/microsoftteams/platform/task-modules-and-cards/cards/design-effective-cards?tabs=design) and [Build Cards](https://learn.microsoft.com/en-us/microsoftteams/platform/task-modules-and-cards/what-are-cards)
+* **Design**: [The Microsoft Teams UI Kit](https://www.figma.com/community/file/916836509871353159)
+* **Build**: [Adaptive Card Designer](https://dev.teams.microsoft.com/cards)
+
+## Contribute
+
+Refer to the [contribution docs](/CONTRIBUTE.md) for more information.

--- a/samples/team-standup-summary/card.json
+++ b/samples/team-standup-summary/card.json
@@ -1,0 +1,454 @@
+{
+    "type": "AdaptiveCard",
+    "$schema": "https://adaptivecards.io/schemas/adaptive-card.json",
+    "version": "1.5",
+    "body": [
+        {
+            "type": "TextBlock",
+            "text": "Daily Standup Summary",
+            "wrap": true,
+            "size": "Large",
+            "weight": "Bolder"
+        },
+        {
+            "type": "ColumnSet",
+            "columns": [
+                {
+                    "type": "Column",
+                    "width": "stretch",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "Design Systems Team",
+                            "wrap": true,
+                            "weight": "Bolder"
+                        }
+                    ],
+                    "verticalContentAlignment": "Center"
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "Badge",
+                            "text": "3 of 4 reported",
+                            "style": "Informative",
+                            "appearance": "Tint",
+                            "icon": "People"
+                        }
+                    ]
+                }
+            ],
+            "targetWidth": "AtLeast:Narrow"
+        },
+        {
+            "type": "Container",
+            "targetWidth": "VeryNarrow",
+            "items": [
+                {
+                    "type": "TextBlock",
+                    "text": "Design Systems Team",
+                    "wrap": true,
+                    "weight": "Bolder"
+                },
+                {
+                    "type": "Badge",
+                    "text": "3 of 4 reported",
+                    "style": "Informative",
+                    "appearance": "Tint",
+                    "icon": "People",
+                    "spacing": "ExtraSmall",
+                    "horizontalAlignment": "Left"
+                }
+            ]
+        },
+        {
+            "type": "TextBlock",
+            "text": "Wed, Feb 12, 2025 · 9:30 AM",
+            "wrap": true,
+            "size": "Small",
+            "isSubtle": true,
+            "spacing": "ExtraSmall"
+        },
+        {
+            "type": "Container",
+            "layouts": [
+                {
+                    "type": "Layout.AreaGrid",
+                    "targetWidth": "atLeast:Standard",
+                    "columns": [50],
+                    "areas": [
+                        { "name": "member1" },
+                        { "name": "member2", "column": 2 },
+                        { "name": "member3", "row": 2 },
+                        { "name": "member4", "column": 2, "row": 2 }
+                    ],
+                    "columnSpacing": "Default",
+                    "rowSpacing": "Default"
+                }
+            ],
+            "items": [
+                {
+                    "type": "Container",
+                    "grid.area": "member1",
+                    "style": "emphasis",
+                    "roundedCorners": true,
+                    "showBorder": true,
+                    "items": [
+                        {
+                            "type": "ColumnSet",
+                            "columns": [
+                                {
+                                    "type": "Column",
+                                    "width": "auto",
+                                    "items": [
+                                        {
+                                            "type": "Image",
+                                            "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/insights/assets/avatar-requestor.png",
+                                            "width": "32px",
+                                            "height": "32px",
+                                            "style": "Person"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "Column",
+                                    "width": "stretch",
+                                    "items": [
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "Alex Chen",
+                                            "wrap": true,
+                                            "weight": "Bolder",
+                                            "size": "Small"
+                                        },
+                                        {
+                                            "type": "Badge",
+                                            "text": "On track",
+                                            "style": "Good",
+                                            "appearance": "Tint",
+                                            "icon": "CheckmarkCircle",
+                                            "size": "Medium"
+                                        }
+                                    ],
+                                    "spacing": "Small"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "TextBlock",
+                            "text": "**Yesterday:** Completed token migration for Button component",
+                            "wrap": true,
+                            "size": "Small",
+                            "spacing": "Small"
+                        },
+                        {
+                            "type": "TextBlock",
+                            "text": "**Today:** Starting Dialog accessibility audit",
+                            "wrap": true,
+                            "size": "Small",
+                            "spacing": "ExtraSmall"
+                        }
+                    ]
+                },
+                {
+                    "type": "Container",
+                    "grid.area": "member2",
+                    "style": "emphasis",
+                    "roundedCorners": true,
+                    "showBorder": true,
+                    "items": [
+                        {
+                            "type": "ColumnSet",
+                            "columns": [
+                                {
+                                    "type": "Column",
+                                    "width": "auto",
+                                    "items": [
+                                        {
+                                            "type": "Image",
+                                            "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/insights/assets/avatar-approver1.png",
+                                            "width": "32px",
+                                            "height": "32px",
+                                            "style": "Person"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "Column",
+                                    "width": "stretch",
+                                    "items": [
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "Priya Sharma",
+                                            "wrap": true,
+                                            "weight": "Bolder",
+                                            "size": "Small"
+                                        },
+                                        {
+                                            "type": "Badge",
+                                            "text": "Blocked",
+                                            "style": "Attention",
+                                            "appearance": "Tint",
+                                            "icon": "Warning",
+                                            "size": "Medium"
+                                        }
+                                    ],
+                                    "spacing": "Small"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "TextBlock",
+                            "text": "**Yesterday:** Worked on responsive grid component",
+                            "wrap": true,
+                            "size": "Small",
+                            "spacing": "Small"
+                        },
+                        {
+                            "type": "TextBlock",
+                            "text": "**Blocker:** Waiting on design specs for breakpoints",
+                            "wrap": true,
+                            "size": "Small",
+                            "spacing": "ExtraSmall",
+                            "color": "Attention"
+                        }
+                    ]
+                },
+                {
+                    "type": "Container",
+                    "grid.area": "member3",
+                    "style": "emphasis",
+                    "roundedCorners": true,
+                    "showBorder": true,
+                    "items": [
+                        {
+                            "type": "ColumnSet",
+                            "columns": [
+                                {
+                                    "type": "Column",
+                                    "width": "auto",
+                                    "items": [
+                                        {
+                                            "type": "Image",
+                                            "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/insights/assets/avatar-approver2.png",
+                                            "width": "32px",
+                                            "height": "32px",
+                                            "style": "Person"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "Column",
+                                    "width": "stretch",
+                                    "items": [
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "Marcus Johnson",
+                                            "wrap": true,
+                                            "weight": "Bolder",
+                                            "size": "Small"
+                                        },
+                                        {
+                                            "type": "Badge",
+                                            "text": "On track",
+                                            "style": "Good",
+                                            "appearance": "Tint",
+                                            "icon": "CheckmarkCircle",
+                                            "size": "Medium"
+                                        }
+                                    ],
+                                    "spacing": "Small"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "TextBlock",
+                            "text": "**Yesterday:** Fixed 3 a11y issues in DatePicker",
+                            "wrap": true,
+                            "size": "Small",
+                            "spacing": "Small"
+                        },
+                        {
+                            "type": "TextBlock",
+                            "text": "**Today:** Writing unit tests for DatePicker fixes",
+                            "wrap": true,
+                            "size": "Small",
+                            "spacing": "ExtraSmall"
+                        }
+                    ]
+                },
+                {
+                    "type": "Container",
+                    "grid.area": "member4",
+                    "style": "emphasis",
+                    "roundedCorners": true,
+                    "showBorder": true,
+                    "items": [
+                        {
+                            "type": "ColumnSet",
+                            "columns": [
+                                {
+                                    "type": "Column",
+                                    "width": "auto",
+                                    "items": [
+                                        {
+                                            "type": "Image",
+                                            "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/insights/assets/avatar-approver3.png",
+                                            "width": "32px",
+                                            "height": "32px",
+                                            "style": "Person"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "Column",
+                                    "width": "stretch",
+                                    "items": [
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "Sara Kim",
+                                            "wrap": true,
+                                            "weight": "Bolder",
+                                            "size": "Small"
+                                        },
+                                        {
+                                            "type": "Badge",
+                                            "text": "Not reported",
+                                            "style": "Warning",
+                                            "appearance": "Tint",
+                                            "icon": "Clock",
+                                            "size": "Medium"
+                                        }
+                                    ],
+                                    "spacing": "Small"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "TextBlock",
+                            "text": "No status update submitted yet.",
+                            "wrap": true,
+                            "size": "Small",
+                            "isSubtle": true,
+                            "spacing": "Small"
+                        }
+                    ]
+                }
+            ],
+            "spacing": "Medium",
+            "separator": true
+        },
+        {
+            "type": "Container",
+            "style": "attention",
+            "roundedCorners": true,
+            "showBorder": true,
+            "spacing": "Medium",
+            "items": [
+                {
+                    "type": "ColumnSet",
+                    "columns": [
+                        {
+                            "type": "Column",
+                            "width": "auto",
+                            "items": [
+                                {
+                                    "type": "Icon",
+                                    "name": "Warning",
+                                    "size": "xSmall",
+                                    "color": "Attention"
+                                }
+                            ],
+                            "verticalContentAlignment": "Center"
+                        },
+                        {
+                            "type": "Column",
+                            "width": "stretch",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "1 blocker needs attention",
+                                    "wrap": true,
+                                    "size": "Small",
+                                    "weight": "Bolder"
+                                }
+                            ],
+                            "spacing": "Small",
+                            "verticalContentAlignment": "Center"
+                        }
+                    ]
+                },
+                {
+                    "type": "TextBlock",
+                    "text": "Priya Sharma is blocked waiting on design specs for responsive breakpoints.",
+                    "wrap": true,
+                    "size": "Small",
+                    "spacing": "ExtraSmall"
+                }
+            ]
+        },
+        {
+            "type": "ColumnSet",
+            "columns": [
+                {
+                    "type": "Column",
+                    "width": "stretch",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "Sprint 24 · Day 7 of 14",
+                            "wrap": true,
+                            "size": "Small",
+                            "isSubtle": true
+                        }
+                    ],
+                    "verticalContentAlignment": "Center"
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "12 tasks remaining",
+                            "wrap": true,
+                            "size": "Small",
+                            "isSubtle": true
+                        }
+                    ],
+                    "verticalContentAlignment": "Center",
+                    "targetWidth": "AtLeast:Narrow"
+                }
+            ],
+            "spacing": "Medium",
+            "separator": true
+        },
+        {
+            "type": "TextBlock",
+            "text": "12 tasks remaining",
+            "wrap": true,
+            "size": "Small",
+            "isSubtle": true,
+            "targetWidth": "VeryNarrow",
+            "spacing": "ExtraSmall"
+        },
+        {
+            "type": "ActionSet",
+            "spacing": "Medium",
+            "actions": [
+                {
+                    "type": "Action.OpenUrl",
+                    "title": "View sprint board",
+                    "url": "https://github.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples"
+                },
+                {
+                    "type": "Action.OpenUrl",
+                    "title": "Submit update",
+                    "url": "https://github.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## Summary

Adds two new sample cards that demonstrate **responsive layout** patterns using `Layout.AreaGrid` and `targetWidth` breakpoints:

### 1. Team Standup Summary
- Displays daily standup status for team members with avatar, progress notes, and blocker highlights
- Uses `Layout.AreaGrid` with `targetWidth: "atLeast:Standard"` to render a **2x2 grid** on desktop that collapses to a **single-column stack** on Narrow/VeryNarrow
- Dual-rendered header: `ColumnSet` for Narrow+ and stacked `Container` for VeryNarrow
- `Badge` components for status indicators (On track, Blocked, Not reported)
- Attention-styled blocker summary container for immediate visibility

### 2. Project Dashboard
- Comprehensive project overview with KPI tiles, milestone timeline, team roster, and activity feed
- **Two `Layout.AreaGrid` layouts on KPI container**: 4-column row at Standard+, 2x2 grid at Narrow, default stack at VeryNarrow
- `Layout.AreaGrid` on milestones/team section for 60/40 side-by-side at Standard+ → stacked on mobile
- `targetWidth` on individual elements to conditionally show/hide timestamps and dates
- `RichTextBlock` activity feed with mixed-weight inline text

### Responsive features demonstrated
| Feature | Team Standup | Project Dashboard |
|---|---|---|
| `Layout.AreaGrid` | ✅ | ✅ (multiple) |
| `targetWidth` on layouts | ✅ | ✅ |
| `targetWidth` on elements | ✅ | ✅ |
| `Badge` component | ✅ | ✅ |
| `Icon` component | ✅ | ✅ |
| `RichTextBlock` | — | ✅ |
| Dual-rendered content | ✅ | ✅ |

Both samples include full `README.md` with responsive layout documentation, breakpoint tables, and implementation details. `catalog.json` updated with both entries.

## Test plan
- [x] Validate card JSON in [Adaptive Card Designer](https://dev.teams.microsoft.com/cards)
- [x] Test at VeryNarrow, Narrow, Standard, and Wide breakpoints
- [ ] Verify Light Mode, Dark Mode, and High Contrast themes
- [ ] Test on mobile (iOS portrait/landscape, Android portrait/landscape)
- [ ] Verify `catalog.json` loads correctly